### PR TITLE
Use GitHub Apps authorization method

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,7 +59,7 @@ staticman:
       type               : "date"
       options:
         format           : "iso8601" # (default), "timestamp-seconds", "timestamp-milliseconds"
-  endpoint               : https://staticman.peoplesoftmods.com/v3/entry/github/ # URL of your own deployment with trailing slash, will fallback to the public instance
+  endpoint               : https://staticman.peoplesoftmods.com/v3/entry/github/ # URL of your own deployment with trailing slash
 reCaptcha:
   siteKey                : "6LffKAkTAAAAACvkzc5Lqujljf7yCbLNnYp1qhm4"
   secret                 : "XjE3WSNGjkDlLgcOngNgVNCXUkICQkxN+erMFn8HmSODHrnTH0IuljzKrafparabWRvekAWLh37LL4Oi6jEIRxZepMEHPG9an+PXZhbT7nHwmq5Hz+6ugQFicyWejYfHfcck4knaDQ9J9ZcHqSNjwFvx/YDBW3jbIYOGmKMh5J741fXuYKT0U7yX1tK6KFBnLTIMalOJCWekCXsEFlj6amREN7skvHEa/krEgyeUNnbuUQMwLnkpJflDiN9INjIXjAd4LeMcjZreJMcwcJsjJcU9frrR4wd0YEFW/l8RgCyXFP2+xbztss8thoNdCo6KaAfBFi6RwKU5ODF0d1dq2Q=="


### PR DESCRIPTION
# Motivation

I've observed that many comments in this repo is in fact sραm.

:warning: **Don't merge this!  I just wanna make an issue.*

# Description

Please use the latest GitHub App authorization method b/c everyone can make use of your GitHub bot <span>@</span>staticman-peoplesoftmods unless you [disabled your `v*/connect` route](https://www.gabescode.com/staticman/2019/01/03/create-staticman-instance.html).

In the [recently updated Staticman quick start guide](https://staticman.net/docs/getting-started.html), which covers Staticman v3, it's recommended to use a private GitHub App so that only the owner can use the GitHub App.